### PR TITLE
Added 'output' directive to specify final target name

### DIFF
--- a/builder.go
+++ b/builder.go
@@ -61,6 +61,7 @@ func runStage(s Stage) {
 func run() {
 	percentPer = 100 / float64(nSteps)
 	progress = 0
+	oname = ""
 	printProgress("Beginning build")
 	for _, stage := range script {
 		runStage(stage)

--- a/flagcompiler.go
+++ b/flagcompiler.go
@@ -18,6 +18,7 @@ var cflags []string
 var cxxflags []string
 var ldflags []string
 var libs []string
+var oname string
 
 func pkgconfig(which string, pkgs []string) []string {
 	cmd := exec.Command("pkg-config", append([]string{which}, pkgs...)...)
@@ -51,6 +52,8 @@ func parseFile(filename string) {
 			cxxflags = append(cxxflags, parts[1:]...)
 		case "LDFLAGS:":
 			ldflags = append(ldflags, parts[1:]...)
+		case "output:":
+			oname = parts[1]
 		case "pkg-config:":
 			xcflags := pkgconfig("--cflags", parts[1:])
 			xlibs := pkgconfig("--libs", parts[1:])
@@ -83,6 +86,7 @@ func compileFlags() {
 	cflags = append(cflags, strings.Fields(os.Getenv("CFLAGS"))...)
 	cxxflags = append(cxxflags, strings.Fields(os.Getenv("CXXFLAGS"))...)
 	ldflags = append(ldflags, strings.Fields(os.Getenv("LDFLAGS"))...)
+	oname = ""
 
 	for _, f := range cfiles {
 		parseFile(f)

--- a/gcc.go
+++ b/gcc.go
@@ -93,11 +93,15 @@ func (g *GCCBase) BuildRCFile(filename string, cflags []string) (stages []Stage,
 	return stages, object
 }
 
-func (g *GCCBase) Link(objects []string, ldflags []string, libs []string) *Step {
+func (g *GCCBase) Link(objects []string, ldflags []string, libs []string, target string) *Step {
 	if g.LD == "" {
 		g.LD = g.CC
 	}
-	target := targetName()
+
+	if target == "" {
+		target = targetName()
+	}
+
 	for i := 0; i < len(libs); i++ {
 		libs[i] = "-l" + libs[i]
 	}

--- a/msvc.go
+++ b/msvc.go
@@ -98,8 +98,11 @@ func (m *MSVC) BuildRCFile(filename string, cflags []string) (stages []Stage, ob
 	return stages, object
 }
 
-func (m *MSVC) Link(objects []string, ldflags []string, libs []string) *Step {
-	target := targetName()
+func (m *MSVC) Link(objects []string, ldflags []string, libs []string, target string) *Step {
+	
+	if target == "" {
+		target = targetName()
+	}
 	for i := 0; i < len(libs); i++ {
 		libs[i] = libs[i] + ".lib"
 	}

--- a/scriptgen.go
+++ b/scriptgen.go
@@ -66,7 +66,7 @@ func buildScript() {
 		objects = append(objects, obj)
 	}
 
-	s := toolchain.Link(objects, ldflags, libs)
+	s := toolchain.Link(objects, ldflags, libs, oname)
 	script = append(script, Stage{s})
 	nSteps++
 }

--- a/toolchain.go
+++ b/toolchain.go
@@ -15,7 +15,7 @@ type Toolchain interface {
 	BuildMFile(filename string, cflags []string) (stages []Stage, object string)
 	BuildMMFile(filename string, cflags []string) (stages []Stage, object string)
 	BuildRCFile(filename string, cflags []string) (stages []Stage, object string)
-	Link(objects []string, ldflags []string, libs []string) *Step
+	Link(objects []string, ldflags []string, libs []string, target string) *Step
 }
 
 var toolchains = make(map[string]Toolchain)


### PR DESCRIPTION
If specified - 'output = filename' enables qo to link all the object files together under that filename;  falls back on directory name as output name if directive is unspecified.
